### PR TITLE
Add manageProgram to set manage.py path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This extension contributes the following settings:
 - `python.djangoTestRunner.djangoNose`: if checked will use django-nose syntax for running class/method tests inside a file, defaults to non-nose testing syntax
 - `python.djangoTestRunner.flags`: any flags you wish to run such as --nocapture, also useful for specifying different settings if you use a modified manage&#46;py
 - `python.djangoTestRunner.prefixCommand`: any command(s) to be directly before the main test command e.g. "cd ~/Projects/hello-world/src &&" to cd into the directory containing your manage&#46;py
+- `python.djangoTestRunner.manageProgram`: the manage&#46;py script to invoke (default=`./manage.py`)
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,17 @@
                 }
             },
             {
+                "title": "Manage program",
+                "properties": {
+                    "python.djangoTestRunner.manageProgram": {
+                        "type": "string",
+                        "default": "./manage.py",
+                        "description": "The path to the manage.py script",
+                        "scope": "resource"
+                    }
+                }
+            },
+            {
                 "title": "Test Flags",
                 "properties": {
                     "python.djangoTestRunner.flags": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ class TestRunner {
       const cmds = [
         configuration.get("python.djangoTestRunner.prefixCommand"),
         configuration.get("python.pythonPath"),
-        "./manage.py",
+        configuration.get("python.djangoTestRunner.manageProgram"),
         "test",
         configuration.get("python.djangoTestRunner.flags"),
         testPath


### PR DESCRIPTION
Hello!

This pull request (hopefully) adds the ability to specify the `manage.py` script in a slightly better way.

# Problem

The existing implementation does not work for me, because:
* I have a virtual environment (`${workspaceFolder}/.venv`)
* My Django project is in a subdirectory (`${workspaceFolder}/src`)

When attempting to run all tests (`CMD`+`D`, `CMD`+`A`), this results in VSCode attempting to run the following command:
```
.venv/bin/python3 ./manage.py test
```

Using the provided `prefixCommand` configuration option to change the working directory is *not* sufficient, because it is placed *before* the `.venv/bin/python3` component of the command.

# Resolution

This pull request aims to address that issue by allowing the user to specify the location of `manage.py` in full through a new configuration option, defaulting to the current behaviour of `./manage.py` for backwards compatibility.
