### PR TITLE
Allow users to specify root module to remove from test paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ This extension contributes the following settings:
 - `python.djangoTestRunner.djangoNose`: if checked will use django-nose syntax for running class/method tests inside a file, defaults to non-nose testing syntax
 - `python.djangoTestRunner.flags`: any flags you wish to run such as --nocapture, also useful for specifying different settings if you use a modified manage&#46;py
 - `python.djangoTestRunner.prefixCommand`: any command(s) to be directly before the main test command e.g. "cd ~/Projects/hello-world/src &&" to cd into the directory containing your manage&#46;py
+- `python.djangoTestRunner.rootPackageName`: the name of the root package of your application. Can be used in conjunciton with `prefixCommand` to remove the root package name from test file paths.
+  - e.g. if `prefixCommand` is set to `"cd ~/Projects/hello-world/src &&"`, your django project structure may raise errors if test paths are specified with `src.apps.app_name.tests`.
+  - setting this to `"rootPackageName": "src"` will cause file paths to return in the format `apps.app_name.tests`, which has the root packed (`src`) removed from the test path
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "django-test-runner",
     "displayName": "Django Test Runner",
     "description": "Run Django and Django-nose tests in VSCode",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "publisher": "Pachwenko",
     "repository": "https://github.com/Pachwenko/VSCode-Django-Test-Runner",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,17 @@
                         "scope": "resource"
                     }
                 }
+            },
+            {
+                "title": "Root Django Project Package Name",
+                "properties": {
+                    "python.djangoTestRunner.rootPackageName": {
+                        "type": "string",
+                        "default": "",
+                        "description": "The root of your django project, where manage.py is located. This is used to strip the root package from test paths.",
+                        "scope": "resource"
+                    }
+                }
             }
         ],
         "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,27 +60,27 @@ class TestRunner {
       .replace(/\\/g, ".")
       .replace(/\\\\/g, ".")
       .substring(1);
-    this.filePath = this.stripRootModuleIfSpecificied(this.filePath);
+
+      this.stripRootPackageIfSpecified();
   }
 
-  stripRootModuleIfSpecificied(testPath: string): string {
+  stripRootPackageIfSpecified() {
     const editor = vscode.window.activeTextEditor;
-    if (!editor) { return testPath; }
+    if (!editor) { return this.filePath; }
     const config = vscode.workspace.getConfiguration("", editor.document.uri);
-    let rootModule: string = config.get("python.djangoTestRunner.rootModuleToRemoveFromPath") || '';
-    
-    if (!rootModule) { return testPath; }
 
-    if (!rootModule.endsWith('.')) { rootModule += '.'; }
-    
-    let idxOfRootModuleSubstrStart = testPath.indexOf(rootModule);
+    let rootPackage: string = config.get("python.djangoTestRunner.rootPackageName") || '';
+    if (!rootPackage) { return this.filePath; }
 
-    if (idxOfRootModuleSubstrStart < 0) {
-      return testPath;
-    } else {
-      let idxOfRootModuleSubstrEnd = idxOfRootModuleSubstrStart + rootModule.length;
-      return testPath.substring(idxOfRootModuleSubstrEnd);
-    }
+    // ensure that rootpath ends with a period as the period need to be stripped as well
+    if (!rootPackage.endsWith('.')) { rootPackage += '.'; }
+
+    let idxOfRootModuleSubstrStart = this.filePath.indexOf(rootPackage);
+    if (idxOfRootModuleSubstrStart < 0) { return this.filePath; }
+
+    // assign this.filepath = everything after the end of rootModule
+    let idxOfRootModuleSubstrEnd = idxOfRootModuleSubstrStart + rootPackage.length;
+    this.filePath = this.filePath.substring(idxOfRootModuleSubstrEnd);
   }
 
   updateClassAndMethodPath(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,27 @@ class TestRunner {
       .replace(/\\/g, ".")
       .replace(/\\\\/g, ".")
       .substring(1);
+    this.filePath = this.stripRootModuleIfSpecificied(this.filePath);
+  }
+
+  stripRootModuleIfSpecificied(testPath: string): string {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) { return testPath; }
+    const config = vscode.workspace.getConfiguration("", editor.document.uri);
+    let rootModule: string = config.get("python.djangoTestRunner.rootModuleToRemoveFromPath") || '';
+    
+    if (!rootModule) { return testPath; }
+
+    if (!rootModule.endsWith('.')) { rootModule += '.'; }
+    
+    let idxOfRootModuleSubstrStart = testPath.indexOf(rootModule);
+
+    if (idxOfRootModuleSubstrStart < 0) {
+      return testPath;
+    } else {
+      let idxOfRootModuleSubstrEnd = idxOfRootModuleSubstrStart + rootModule.length;
+      return testPath.substring(idxOfRootModuleSubstrEnd);
+    }
   }
 
   updateClassAndMethodPath(): void {


### PR DESCRIPTION
**Bug that's being fixed**
my django application is structured like this, and I open up the repo into the `repo_name/` directory.
```
repo_name/
    .gitignore
    dev_tools/
    src/
        manage.py
        apps/
            app_name_1/
            app_name_2/
            app_name_etc/
```

Setting `prefixCommand` alone is not enough, as the command ends up being `cd ~/my_user/projects/hello-world/src && python manage.py test src.apps.app_name_1.tests`, which results in a `ModuleNotFoundError` since the command is running in the `src/` directory.

**Description of work**
This PR allows a user to specify, in their vscode setting.json file, `"rootPackageName": "name_of_root_python_package"`. 

If this setting is specified, the string `name_of_root_python_package.` (notice the period at the end) is stripped from the beginning of the test path.

This results in the command run being: `cd ~/my_user/projects/hello-world/src && python manage.py test apps.app_name_1.tests`