### PR TITLE
Add some of the run-test commands to the editor's context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "django-test-runner" extension will be documented in 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.0] - 2020-05-13
+
+### Added
+
+- Add test-running commands to the editor's context menu
+
 ## [3.0.4] - 2019-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Draws inspiration from [vscode-django-tests](https://github.com/remik/vscode-dja
 
 ## Features
 
-Default shortcuts:
+### Default shortcuts:
 
 ```
 Run Closest Test Method: cmd+d+m        extension.djangoTestRunner.runMethodTests
@@ -42,6 +42,14 @@ VSCodevim keybindings (put these in your settings.json file):
 ],
 ```
 
+### Context menu
+
+By default, this extension adds the following items to the editor's context menu:
+
+ - Run Closest Test Method
+ - Run Closest Test Class
+ - Run Current Test File
+
 ## Requirements
 
 Requires manage&#46;py to be in the root workspace directory, otherwise add a cd command to the `python.djangoTestRunner.prefixCommand` settings such as "cd ~/Projects/hello-world/src &&"
@@ -53,6 +61,7 @@ This extension contributes the following settings:
 - `python.djangoTestRunner.djangoNose`: if checked will use django-nose syntax for running class/method tests inside a file, defaults to non-nose testing syntax
 - `python.djangoTestRunner.flags`: any flags you wish to run such as --nocapture, also useful for specifying different settings if you use a modified manage&#46;py
 - `python.djangoTestRunner.prefixCommand`: any command(s) to be directly before the main test command e.g. "cd ~/Projects/hello-world/src &&" to cd into the directory containing your manage&#46;py
+- `python.djangoTestRunner.showCommandsInContextMenu`: if checked will add commands to the editor's context menu
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "django-test-runner",
     "displayName": "Django Test Runner",
     "description": "Run Django and Django-nose tests in VSCode",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "publisher": "Pachwenko",
     "repository": "https://github.com/Pachwenko/VSCode-Django-Test-Runner",
     "engines": {
@@ -60,6 +60,16 @@
                         "scope": "resource"
                     }
                 }
+            },
+            {
+                "title": "Context menu items",
+                "properties": {
+                    "python.djangoTestRunner.showCommandsInContextMenu": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Whether or not to show commands in editor's context menu"
+                    }
+                }
             }
         ],
         "commands": [
@@ -84,6 +94,25 @@
                 "title": "python.djangoTestRunner: Run Current App Tests"
             }
         ],
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "python.djangoTestRunner.runMethodTests",
+                    "group": "Django Test Runner",
+                    "when": "config.python.djangoTestRunner.showCommandsInContextMenu"
+                },
+                {
+                    "command": "python.djangoTestRunner.runClassTests",
+                    "group": "Django Test Runner@1",
+                    "when": "config.python.djangoTestRunner.showCommandsInContextMenu"
+                },
+                {
+                    "command": "python.djangoTestRunner.runFileTests",
+                    "group": "Django Test Runner@2",
+                    "when": "config.python.djangoTestRunner.showCommandsInContextMenu"
+                }
+            ]
+        },
         "keybindings": [
             {
                 "command": "python.djangoTestRunner.runMethodTests",


### PR DESCRIPTION
It can be useful to run tests via a context (right-click) menu.  PR includes an option to toggle the feature on/off.