### PR TITLE
Add custom manage file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,17 @@
                         "scope": "resource"
                     }
                 }
+            },
+            {
+                "title": "Manage file path",
+                "properties": {
+                    "python.djangoTestRunner.manageFilePath": {
+                        "type": "string",
+                        "default": "./manage.py",
+                        "description": "Django manage.py execution file path",
+                        "scope": "resource"
+                    }
+                }
             }
         ],
         "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { WorkspaceConfiguration } from "vscode";
 
 const METHOD_REGEX = /(\s*)def\s+(test_\w+)\s?\(/i;
 const CLASS_REGEX = /(\s*)class\s+(\w+)/i;
@@ -133,8 +134,7 @@ class TestRunner {
       terminal.show();
       const cmds = [
         configuration.get("python.djangoTestRunner.prefixCommand"),
-        configuration.get("python.pythonPath"),
-        "./manage.py",
+        configuration.get("python.djangoTestRunner.manageFilePath"),
         "test",
         configuration.get("python.djangoTestRunner.flags"),
         testPath


### PR DESCRIPTION
## Summary

Closes issue #13 

Also removed the python runner prefix since it either would be the default PATH python or the venv one. It's more flexible since python could be added to the prefix configuration and would block the usage of a .sh file. 